### PR TITLE
Parse temperature values to show temp, min, and max

### DIFF
--- a/atasmart
+++ b/atasmart
@@ -56,11 +56,17 @@
 /^208 187/	{print "Reported Uncorrectable Errors", $3; next}
 /^208 188/	{print "Command Timeout", $3; next}
 /^208 189/	{print "High Fly Writes", $3; next}
-/^208 190/	{print "Temperature Difference", $3; next}
+/^208 190/	{
+	print "Temperature Difference", ($3 % 256), "Min", (int($3 / (256*256)) % 256), "Max", int($3 / (256*256*256)); 
+	next
+}
 /^208 191/	{print "G-sense Error Rate", $3; next}
 /^208 192/	{print "Power-off Retract Count", $3; next}
 /^208 193/	{print "Load Cycle Count", $3; next}
-/^208 194/	{print "Temperature", $3; next}
+/^208 194/	{
+	print "Temperature", ($3 % 256), "Min", (int($3 / (256*256)) % 256), "Max", int($3 / (256*256*256*256)); 
+	next
+}
 /^208 195/	{print "Hardware ECC Recovered", $3; next}
 /^208 196/	{print "Reallocation Event Count", $3; next}
 /^208 197/	{print "Current Pending Sector", $3; next}


### PR DESCRIPTION
Changed atasmart to decode the current, min, and max values for temperatures, 190 and 194.
For all drives I could test on, this works for the current value.
With 1 exception (a Lenovo branded WD 1TB enterprise) , this shows the min and max in cases where smartctl would.

It does show unlikely numbers in a few cases, where smartctl shows nothing or doesn't mark it as a min or max.  So there is some improvement to still be made.