### PR TITLE
Fix issue 10

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,4 @@
-This file documents changes for smart release
+This file documents changes for smart releases
 
 version 1.0.0
  - Fix ATA threshold output (gh-10). This is a breaking change as it

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,15 @@
 This file documents changes for smart release
 
+version 1.0.0
+ - Fix ATA threshold output (gh-10). This is a breaking change as it
+   reduces the output from 4 fields to 3 (drops the "reserved" byte
+   from threshold).
+ - Fix the ATA raw output. This is a breaking change as it increase the
+   output from 6 bytes to 7 (i.e., includes the "reserved" byte). Note
+   that while some attributes use this byte, most do not.
+ - Fix direct debug output (--debug) to standard error
+ - Use POSIX memcpy and memset instead of older bXXX equivalents
+
 version 0.4.2
  - Update README contents
 

--- a/libsmart.c
+++ b/libsmart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 Chuck Tuffli <chuck@tuffli.net>
+ * Copyright (c) 2016-2026 Chuck Tuffli <chuck@tuffli.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -242,8 +242,8 @@ smart_free(smart_map_t *sm)
 /* Long integer version of the format macro */
 # define RAW_LHEX	"%#01.1" PRIx64
 # define RAW_LDEC	"%" PRId64
-# define THRESH_HEX	"\t%#02.2x\t%#01.1x\t%#01.1x\t%#01.1x"
-# define THRESH_DEC	"\t%d\t%d\t%d\t%d"
+# define THRESH_HEX	"\t%#02.2x\t%#01.1x\t%#01.1x"
+# define THRESH_DEC	"\t%d\t%d\t%d"
 # define DESC_STR	"%s"
 #else
 # define __smart_print_val(fmt, ...) 	 xo_emit(fmt, ##__VA_ARGS__)
@@ -261,10 +261,12 @@ smart_free(smart_map_t *sm)
 /* Long integer version of the format macro */
 # define RAW_LHEX	"{k:raw/%#01.1" PRIx64 "}"
 # define RAW_LDEC	"{k:raw/%" PRId64 "}"
-# define THRESH_HEX	"{P:\t}{k:threshold/%#02.2x\t%#01.1x\t%#01.1x\t%#01.1x}"
-# define THRESH_DEC	"{P:\t}{k:threshold/%d\t%d\t%d\t%d}"
+# define THRESH_HEX	"{P:\t}{k:flags/%#02.2x}{P:\t}{k:nominal/%#01.1x}{P:\t}{k:worst/%#01.1x}"
+# define THRESH_DEC	"{P:\t}{k:flags/%d}{P:\t}{k:nominal/%d}{P:\t}{k:worst/%d}"
 # define DESC_STR	"{:description}{P:\t}"
 #endif
+
+#define THRESH_COUNT	3
 
 
 /* Convert an 128-bit unsigned integer to a string */
@@ -315,7 +317,6 @@ static void
 __smart_print_thresh(smart_map_t *tm, uint32_t flags)
 {
 	bool do_hex = false;
-	bool do_thresh = false;
 
 	if (!tm) {
 		return;
@@ -324,16 +325,10 @@ __smart_print_thresh(smart_map_t *tm, uint32_t flags)
 	if (flags & SMART_OPEN_F_HEX)
 		do_hex = true;
 
-	if (flags & SMART_OPEN_F_THRESH)
-		do_thresh = true;
-
-	if (do_thresh && tm) {
-		__smart_print_val(do_hex ? THRESH_HEX : THRESH_DEC,
-				*((uint16_t *)tm->attr[0].raw),
-				*((uint8_t *)tm->attr[1].raw),
-				*((uint8_t *)tm->attr[2].raw),
-				*((uint8_t *)tm->attr[3].raw));
-	}
+	__smart_print_val(do_hex ? THRESH_HEX : THRESH_DEC,
+			*((uint16_t *)tm->attr[0].raw),
+			*((uint8_t *)tm->attr[1].raw),
+			*((uint8_t *)tm->attr[2].raw));
 }
 
 /* Does the attribute match one requested by the caller? */
@@ -466,7 +461,11 @@ smart_print(smart_h h, smart_map_t *sm, smart_matches_t *which, uint32_t flags)
 			__smart_print_val(do_hex ? RAW_HEX : RAW_DEC, v8);
 		}
 
-		__smart_print_thresh(sm->attr[i].thresh, flags);
+		if ((flags & SMART_OPEN_F_THRESH) && sm->attr[i].thresh) {
+			xo_open_container("threshold");
+			__smart_print_thresh(sm->attr[i].thresh, flags);
+			xo_close_container("threshold");
+		}
 
 		__smart_print_val("\n");
 
@@ -580,17 +579,21 @@ __smart_buffer_size(smart_h h)
 	return size;
 }
 
-/* Map SMART READ DATA threshold attributes */
+/*
+ * Map SMART READ DATA threshold attributes
+ *
+ * Read the 3 consecutive values (flags, nominal, and worst)
+ */
 static smart_map_t *
 __smart_map_ata_thresh(uint8_t *b)
 {
 	smart_map_t *sm = NULL;
 
-	sm = malloc(sizeof(smart_map_t) + (4 * sizeof(smart_attr_t)));
+	sm = malloc(sizeof(smart_map_t) + (THRESH_COUNT * sizeof(smart_attr_t)));
 	if (sm) {
 		uint32_t i;
 
-		sm->count = 4;
+		sm->count = THRESH_COUNT;
 
 		sm->attr[0].page = 0;
 		sm->attr[0].id = 0;
@@ -610,16 +613,27 @@ __smart_map_ata_thresh(uint8_t *b)
 			sm->attr[i].thresh = NULL;
 
 			b ++;
-
-			if (i == 2)
-				b += 6;
 		}
 	}
 
 	return sm;
 }
 
-/* Map SMART READ DATA attributes */
+/*
+ * Map SMART READ DATA attributes
+ *
+ * The format for the READ DATA buffer is:
+ *    2 bytes Revision
+ *  360 bytes Attributes (12 bytes each)
+ *   
+ * Each attribute consists of:
+ *   1 byte ID
+ *   2 byte Status Flags
+ *   1 byte Nominal value
+ *   1 byte Worst value
+ *   7 byte Raw value
+ * Note that many attributes do not use the entire 7 bytes of the raw value.
+ */
 static void
 __smart_map_ata_read_data(smart_map_t *sm, void *buf, size_t bsize)
 {
@@ -633,6 +647,7 @@ __smart_map_ata_read_data(smart_map_t *sm, void *buf, size_t bsize)
 
 	b = buf;
 
+	/* skip revision */
 	b += 2;
 
 	b_end = b + (max_attr * 12);
@@ -649,7 +664,7 @@ __smart_map_ata_read_data(smart_map_t *sm, void *buf, size_t bsize)
 			sm->attr[a].id = b[0];
 			sm->attr[a].description = __smart_ata_desc(
 			    PAGE_ID_ATA_SMART_READ_DATA, sm->attr[a].id);
-			sm->attr[a].bytes = 6;
+			sm->attr[a].bytes = 7;
 			sm->attr[a].flags = 0;
 			sm->attr[a].raw = b + 5;
 			sm->attr[a].thresh = __smart_map_ata_thresh(b + 1);

--- a/libsmart_priv.h
+++ b/libsmart_priv.h
@@ -33,7 +33,7 @@
 
 extern bool do_debug;
 
-#define dprintf(f, ...)	if (do_debug) printf("dbg: " f, ## __VA_ARGS__)
+#define dprintf(f, ...)	if (do_debug) fprintf(stderr, "dbg: " f, ## __VA_ARGS__)
 
 /* General information about the device */
 typedef struct smart_info_s {

--- a/smart.8
+++ b/smart.8
@@ -1,7 +1,7 @@
 .\"
 .\" SPDX-License-Identifier: BSD-2-Clause-FreeBSD
 .\"
-.\" Copyright (c) 2021 Chuck Tuffli
+.\" Copyright (c) 2021-2026 Chuck Tuffli
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 .\"
 .\" Note: The date here should be updated whenever a non-trivial
 .\" change is made to the manual page.
-.Dd October 8, 2021
+.Dd February 14, 2026
 .Dt SMART 8
 .Os
 .Sh NAME
@@ -54,7 +54,7 @@ Because the structure of this information varies across protocols,
 .Nm
 normalizes entries using the format:
 .Bd -literal
-	<Page ID>    <Attribute ID>    <Value>    <Threshold>
+	<Page ID>    <Attribute ID>    <Value>    <Thresholds>
 .Ed
 .Pp
 Fields are tab-delimited by default, but the command can output
@@ -64,12 +64,27 @@ data in any format supported by
 Because ATA does not have log pages,
 .Nm
 uses the Command Feature field value in place of the log page ID.
-For SMART READ DATA, this value is 208 / 0xd0. Note that devices
-choose which attribute ID values they support and the description
-for it. Additionally,
+For SMART READ DATA, this value is 208 / 0xd0.
+Note that devices choose which attribute ID values they support, their
+descriptions, and the format of the data.
+The three values displayed with the
+.Fl Fl threshold
+option are:
+.Pp
+.Bl -dash -compact -offset indent
+.It
+Status flags (byte offset 1, 2 bytes)
+.It
+Nominal attribute value (byte offset 3, 1 byte)
+.It
+Worst Ever attribute value (byte offset 4, 1 byte)
+.El
+.Pp
+Additionally,
 .Nm
 reports the value of the SMART STATUS command (Command Feature field
-value 218 / 0xda). As this command does not return any data,
+value 218 / 0xda).
+As this command does not return any data,
 the command represents this entry with a synthetic attribute
 ID of 0, and it uses the command status (0 or 1) as the attribute
 value.
@@ -78,15 +93,19 @@ NVMe devices support the SMART/Health log page (Page ID 2 / 0x2).
 The data returned in this log page is not structured as attribute IDs.
 Instead,
 .Nm
-uses the byte offset of each field as the attribute ID. For example,
-byte 3 is the Available Spare. Thus, for NVMe, attribute ID 3 is
-Available Spare. Note that NVMe health data does not include threshold
+uses the byte offset of each field as the attribute ID.
+For example,
+byte 3 is the Available Spare.
+Thus, for NVMe, attribute ID 3 is
+Available Spare.
+Note that NVMe health data does not include threshold
 values, and as a result, the command will ignore the
 .Fl Fl threshold
 option.
 .Pp
 SCSI devices can support a number of log pages which report drive
-health. The command will report the following pages:
+health.
+The command will report the following pages:
 .Pp
 .Bl -dash -compact -offset indent
 .It
@@ -108,10 +127,13 @@ Informational Exceptions (Page ID 47 / 0x2f)
 .El
 .Pp
 Note that all log pages are optional, and a particular drive
-may not support all these pages. For SCSI devices, the Attribute ID
-maps to the SCSI parameter code defined by the command. Parameter
+may not support all these pages.
+For SCSI devices, the Attribute ID
+maps to the SCSI parameter code defined by the command.
+Parameter
 codes are integer values from 0 to N, and, by themselves, are ambiguous
-outside the context of a particular log page. Note that SCSI health data
+outside the context of a particular log page.
+Note that SCSI health data
 does not include threshold values, and as a result, the command will
 ignore the
 .Fl Fl threshold
@@ -210,7 +232,8 @@ The device does not support health data.
 relies on
 .Xr cam 4
 to retrieve data from devices and will display this message if the
-device does not have a passthrough driver. This can happen, for
+device does not have a passthrough driver.
+This can happen, for
 example, if the system uses the
 .Xr nvd 4
 NVMe driver instead of the

--- a/smart.c
+++ b/smart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 Chuck Tuffli <chuck@tuffli.net>
+ * Copyright (c) 2016-2026 Chuck Tuffli <chuck@tuffli.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -26,7 +26,7 @@
 #include "libsmart.h"
 
 #define SMART_NAME "smart"
-#define SMART_VERSION	"0.4.2"
+#define SMART_VERSION	"1.0.0"
 
 const char *pn;
 bool do_debug = false;
@@ -266,7 +266,7 @@ main(int argc, char *argv[])
 
 	if (do_version) {
 		printf("%s, version %s\n", pn, SMART_VERSION);
-		printf("Copyright (c) 2016-2025 Chuck Tuffli\n"
+		printf("Copyright (c) 2016-2026 Chuck Tuffli\n"
 				"This is free software; see the source for copying conditions.\n");
 		return EXIT_SUCCESS;
 	}


### PR DESCRIPTION
The JSON output for ATA drives causes parse errors when including the threshold values. Address this by fixing the XO output to a) create a container for the threshold values and b) name the values.

Fixes #10 